### PR TITLE
[Do not merge] Leaf Mining proof of concept

### DIFF
--- a/scripts/VeinBlocks.ts
+++ b/scripts/VeinBlocks.ts
@@ -35,4 +35,16 @@ VEIN_BLOCKS_LIST.forEach((block) => {
   VEIN_BLOCKS.add(block);
 });
 
-export { VEIN_BLOCKS };
+const LEAF_BLOCK_LIST = [
+  MinecraftBlockTypes.leaves.id,
+  MinecraftBlockTypes.leaves2.id,
+  MinecraftBlockTypes.azaleaLeaves.id,
+  MinecraftBlockTypes.mangroveLeaves.id,
+];
+
+const LEAF_BLOCKS = new Set<string>();
+LEAF_BLOCK_LIST.forEach((block) => {
+  LEAF_BLOCKS.add(block);
+});
+
+export { VEIN_BLOCKS, LEAF_BLOCKS };

--- a/scripts/VeinBreakEvent.ts
+++ b/scripts/VeinBreakEvent.ts
@@ -1,6 +1,6 @@
 import { BlockBreakEvent, BlockLocation, Dimension } from "@minecraft/server";
 import { destroy } from "./Utilities";
-import { VEIN_BLOCKS } from "./VeinBlocks";
+import { VEIN_BLOCKS, LEAF_BLOCKS } from "./VeinBlocks";
 
 const MAX_DEPTH = 150;
 
@@ -48,8 +48,11 @@ const DFS = (
           continue;
         }
 
-        if (dimension.getBlock(newBlockLocation).type.id === blockTypeId) {
+        const block = dimension.getBlock(newBlockLocation);
+        if (block.type.id === blockTypeId) {
           DFS(newBlockLocation, blockTypeId, depth + 1, visited, dimension);
+        } else if (LEAF_BLOCKS.has(block.type.id)) {
+          destroy(newBlockLocation, dimension);
         }
       }
     }


### PR DESCRIPTION
Since we are investigating the nearby spaces to begin with, we can check if the. This results in adjacent leaves being destroyed with no additional runtime complexity
![image](https://user-images.githubusercontent.com/21363865/219739540-a521c2a9-24d3-4119-8f3e-4237aa3e829f.png)

However. The new issue this causes is we end of overflowing the command queue due to firing off too many setblock commands
![image](https://user-images.githubusercontent.com/21363865/219740222-07dfa097-2f1c-45ad-9aeb-889b3361b60a.png)

I think for this to work, we need someway to utilize the /fill command instead, which appears to support the destroy option so that it drops the actual.  Would this entail building up regions and pasting them into the command line as /fill commands instead of setblock? This would require constructing minimum cubes from our found cubes, which sounds like a dynamic programming problem lol.