### PR TITLE
Vein Family Associations. Migration of Vein_Block_Set to a Map.

### DIFF
--- a/scripts/VeinBlockFamilies.ts
+++ b/scripts/VeinBlockFamilies.ts
@@ -1,33 +1,43 @@
 import { MinecraftBlockTypes } from "@minecraft/server";
 
-export const VEIN_BLOCKS_LIST = [
-  // Logs
-  MinecraftBlockTypes.log.id,
-  MinecraftBlockTypes.log2.id,
-  MinecraftBlockTypes.mangroveLog.id,
+export const REDSTONE_FAMILY = [
+  MinecraftBlockTypes.redstoneOre.id,
+  MinecraftBlockTypes.deepslateRedstoneOre.id,
+  MinecraftBlockTypes.litRedstoneOre.id,
+  MinecraftBlockTypes.litDeepslateRedstoneOre.id,
+];
 
-  // Ore
+export const COAL_FAMILY = [
   MinecraftBlockTypes.coalOre.id,
   MinecraftBlockTypes.deepslateCoalOre.id,
+];
+
+export const IRON_FAMILY = [
   MinecraftBlockTypes.ironOre.id,
   MinecraftBlockTypes.deepslateIronOre.id,
-  MinecraftBlockTypes.redstoneOre.id,
-  MinecraftBlockTypes.litRedstoneOre.id,
-  MinecraftBlockTypes.deepslateRedstoneOre.id,
-  MinecraftBlockTypes.litDeepslateRedstoneOre.id,
+];
+
+export const LAPIS_FAMILY = [
   MinecraftBlockTypes.lapisOre.id,
   MinecraftBlockTypes.deepslateLapisOre.id,
+];
+
+export const DIAMOND_FAMILY = [
   MinecraftBlockTypes.diamondOre.id,
   MinecraftBlockTypes.deepslateDiamondOre.id,
-  MinecraftBlockTypes.copperOre.id,
-  MinecraftBlockTypes.deepslateCopperOre.id,
-  MinecraftBlockTypes.quartzOre.id,
+];
+
+export const COPPER_FAMILY = [
+  MinecraftBlockTypes.diamondOre.id,
+  MinecraftBlockTypes.deepslateDiamondOre.id,
+];
+
+export const GOLD_FAMILY = [
   MinecraftBlockTypes.goldOre.id,
   MinecraftBlockTypes.deepslateGoldOre.id,
-  MinecraftBlockTypes.netherGoldOre.id,
+];
+
+export const EMERALD_FAMILIY = [
   MinecraftBlockTypes.emeraldOre.id,
   MinecraftBlockTypes.deepslateEmeraldOre.id,
-
-  // Other
-  MinecraftBlockTypes.glowstone.id,
 ];

--- a/scripts/VeinBlocksMap.ts
+++ b/scripts/VeinBlocksMap.ts
@@ -1,0 +1,46 @@
+import {
+  COAL_FAMILY,
+  COPPER_FAMILY,
+  DIAMOND_FAMILY,
+  EMERALD_FAMILIY,
+  GOLD_FAMILY,
+  IRON_FAMILY,
+  LAPIS_FAMILY,
+  REDSTONE_FAMILY,
+} from "./VeinBlockFamilies";
+import { VEIN_BLOCKS_LIST } from "./VeinBlocks";
+
+const associateBlockFamilies = (
+  family: String[],
+  map: Map<String, Set<String>>
+) => {
+  family.forEach((node) => {
+    family.forEach((adjacent) => {
+      if (node == adjacent) {
+        return;
+      }
+      map.get(node)?.add(adjacent);
+    });
+  });
+};
+
+// A map of allowed blocks to Vein mine, and a set of allowed destroyable blocks when vein mined
+const VEIN_BLOCKS_MAP = new Map<String, Set<String>>();
+
+// Default each map entry to include itself
+VEIN_BLOCKS_LIST.forEach((block) => {
+  VEIN_BLOCKS_MAP.set(block, new Set<String>());
+  VEIN_BLOCKS_MAP.get(block)?.add(block);
+});
+
+// Populate maps of assocaited blocks.
+associateBlockFamilies(REDSTONE_FAMILY, VEIN_BLOCKS_MAP);
+associateBlockFamilies(COAL_FAMILY, VEIN_BLOCKS_MAP);
+associateBlockFamilies(IRON_FAMILY, VEIN_BLOCKS_MAP);
+associateBlockFamilies(LAPIS_FAMILY, VEIN_BLOCKS_MAP);
+associateBlockFamilies(DIAMOND_FAMILY, VEIN_BLOCKS_MAP);
+associateBlockFamilies(COPPER_FAMILY, VEIN_BLOCKS_MAP);
+associateBlockFamilies(GOLD_FAMILY, VEIN_BLOCKS_MAP);
+associateBlockFamilies(EMERALD_FAMILIY, VEIN_BLOCKS_MAP);
+
+export { VEIN_BLOCKS_MAP };

--- a/scripts/VeinBreakEvent.ts
+++ b/scripts/VeinBreakEvent.ts
@@ -1,13 +1,13 @@
 import { BlockBreakEvent, BlockLocation, Dimension } from "@minecraft/server";
 import { destroy } from "./Utilities";
-import { VEIN_BLOCKS } from "./VeinBlocks";
+import { VEIN_BLOCKS_MAP } from "./VeinBlocksMap";
 
 const MAX_DEPTH = 150;
 
 export const VeinBreakEvent = (blockBreakEvent: BlockBreakEvent) => {
   const brokenBlock = blockBreakEvent.brokenBlockPermutation.type.id;
 
-  if (!VEIN_BLOCKS.has(brokenBlock) || !blockBreakEvent.player.isSneaking) {
+  if (!VEIN_BLOCKS_MAP.has(brokenBlock) || !blockBreakEvent.player.isSneaking) {
     return;
   }
 
@@ -48,7 +48,11 @@ const DFS = (
           continue;
         }
 
-        if (dimension.getBlock(newBlockLocation).type.id === blockTypeId) {
+        if (
+          VEIN_BLOCKS_MAP.get(blockTypeId)?.has(
+            dimension.getBlock(newBlockLocation).type.id
+          )
+        ) {
           DFS(newBlockLocation, blockTypeId, depth + 1, visited, dimension);
         }
       }


### PR DESCRIPTION
Vein blocks are now associated in Families. Blocks within a family can be used to vine mine each other. This is primarily used to allow for vein mining of ore alongside combinations of Deepslate, and Redstone with its lit permutations.

The block break event uses this Map to check if the block is eligible for vein mining, and then if adjacent blocks can be vein mined.

A one way relationship can defined in the future by adding the relationship in one direction in the Map, i.e. do not create a Family for Logs and Leaves

-----
Testing

- Vein mine a group of ore and its deepslate counterparts. Ensure all are mined properly.
- Vein mine trees and ensure previous functionality still holds (We should write unit testing)
- Vein mine redstone and deepslate redstone. Ensure all are mined.

Resolving issues found in 
https://github.com/laynebritton/jl-fast-treecapitator/issues/8 @GlowBrick
https://github.com/laynebritton/jl-fast-treecapitator/issues/7
