### PR TITLE
Bumped API version to stable release. 1.19.60-stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "scripting-starter",
       "version": "0.1.0",
       "dependencies": {
-        "@minecraft/server": "^1.1.0-beta.1.19.60-preview.26",
+        "@minecraft/server": "^1.1.0-beta.1.19.60-stable",
         "decode-uri-component": "^0.2.2"
       },
       "devDependencies": {
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@minecraft/server": {
-      "version": "1.1.0-beta.1.19.60-preview.26",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.1.0-beta.1.19.60-preview.26.tgz",
-      "integrity": "sha512-SR8xaw6tTIAsdJuXcpqYiQd8EAtH8QYQPIKlTjqBZEJcQ8HCBxD5kBAECjYBseTnUIOoJx7UOo7nY7CmvKLjoA=="
+      "version": "1.1.0-beta.1.19.60-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.1.0-beta.1.19.60-stable.tgz",
+      "integrity": "sha512-o7koQPeyX/R+MUdgexYMIfoZtdkWgr51s+e1f7gR2EqomTUu8/J/8N3sDEWIdeMU2zM5MzWaezCJK0+rEUpZTg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5180,9 +5180,9 @@
       }
     },
     "@minecraft/server": {
-      "version": "1.1.0-beta.1.19.60-preview.26",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.1.0-beta.1.19.60-preview.26.tgz",
-      "integrity": "sha512-SR8xaw6tTIAsdJuXcpqYiQd8EAtH8QYQPIKlTjqBZEJcQ8HCBxD5kBAECjYBseTnUIOoJx7UOo7nY7CmvKLjoA=="
+      "version": "1.1.0-beta.1.19.60-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.1.0-beta.1.19.60-stable.tgz",
+      "integrity": "sha512-o7koQPeyX/R+MUdgexYMIfoZtdkWgr51s+e1f7gR2EqomTUu8/J/8N3sDEWIdeMU2zM5MzWaezCJK0+rEUpZTg=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "enablemcpreviewloopback": "CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-424268864-5579737-879501358-346833251-474568803-887069379-4040235476"
   },
   "dependencies": {
-    "@minecraft/server": "^1.1.0-beta.1.19.60-preview.26",
+    "@minecraft/server": "^1.1.0-beta.1.19.60-stable",
     "decode-uri-component": "^0.2.2"
   }
 }


### PR DESCRIPTION
The current iteration of the API is considered stable and this repository should move off a preview build into a stable build. 

Testing
1. Assured original functionality was unchanged between versions. 