### PR TITLE
Migrate API to 1.19.80 stable and update Tree Block IDs

### DIFF
--- a/behavior_packs/jl-fast-treecapitator/manifest.json
+++ b/behavior_packs/jl-fast-treecapitator/manifest.json
@@ -4,7 +4,7 @@
     "name": "JL Fast Treecapitator",
     "description": "Mine trees and veins in 1 click, fast!",
     "uuid": "b1da7c74-d155-4686-a9aa-33d5a6c48da0",
-    "version": [0, 0, 1],
+    "version": [1, 0, 1],
     "min_engine_version": [1, 19, 40]
   },
   "modules": [
@@ -13,14 +13,14 @@
       "language": "javascript",
       "type": "script",
       "uuid": "5ec7117f-d362-4b5b-918e-23f9b3d76476",
-      "version": [0, 0, 1],
+      "version": [1, 0, 1],
       "entry": "scripts/main.js"
     }
   ],
   "dependencies": [
     {
       "module_name": "@minecraft/server",
-      "version": "1.1.0-beta"
+      "version": "1.2.0-beta"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "scripting-starter",
       "version": "0.1.0",
       "dependencies": {
-        "@minecraft/server": "1.2.0-beta.1.19.80-stable",
+        "@minecraft/server": "^1.2.0-beta.1.19.80-stable",
         "decode-uri-component": "^0.2.2"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "scripting-starter",
       "version": "0.1.0",
       "dependencies": {
-        "@minecraft/server": "^1.1.0-beta.1.19.70-stable",
+        "@minecraft/server": "1.2.0-beta.1.19.80-stable",
         "decode-uri-component": "^0.2.2"
       },
       "devDependencies": {
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@minecraft/server": {
-      "version": "1.1.0-beta.1.19.70-stable",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.1.0-beta.1.19.70-stable.tgz",
-      "integrity": "sha512-hdCxtHCh2iPfJO9uZEUcYlPt03xe5FyAjfYUgt8LV+QR81EG6WSz24IFcmNDDyWoBh2nHy/GVLU+xtk0LUhRsg=="
+      "version": "1.2.0-beta.1.19.80-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.2.0-beta.1.19.80-stable.tgz",
+      "integrity": "sha512-EVlPbaMWmQMJtPwCPtRMqsmWLTWzOUzUdBjDZWQ+3hM4Oi4OqoFTR22i+e0CgJ6UVHNx/xNyh5h6h0AV36pkxw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5180,9 +5180,9 @@
       }
     },
     "@minecraft/server": {
-      "version": "1.1.0-beta.1.19.70-stable",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.1.0-beta.1.19.70-stable.tgz",
-      "integrity": "sha512-hdCxtHCh2iPfJO9uZEUcYlPt03xe5FyAjfYUgt8LV+QR81EG6WSz24IFcmNDDyWoBh2nHy/GVLU+xtk0LUhRsg=="
+      "version": "1.2.0-beta.1.19.80-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.2.0-beta.1.19.80-stable.tgz",
+      "integrity": "sha512-EVlPbaMWmQMJtPwCPtRMqsmWLTWzOUzUdBjDZWQ+3hM4Oi4OqoFTR22i+e0CgJ6UVHNx/xNyh5h6h0AV36pkxw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "enablemcpreviewloopback": "CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-424268864-5579737-879501358-346833251-474568803-887069379-4040235476"
   },
   "dependencies": {
-    "@minecraft/server": "1.2.0-beta.1.19.80-stable",
+    "@minecraft/server": "^1.2.0-beta.1.19.80-stable",
     "decode-uri-component": "^0.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "enablemcpreviewloopback": "CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-424268864-5579737-879501358-346833251-474568803-887069379-4040235476"
   },
   "dependencies": {
-    "@minecraft/server": "^1.1.0-beta.1.19.70-stable",
+    "@minecraft/server": "1.2.0-beta.1.19.80-stable",
     "decode-uri-component": "^0.2.2"
   }
 }

--- a/scripts/VeinBlocks.ts
+++ b/scripts/VeinBlocks.ts
@@ -2,8 +2,13 @@ import { MinecraftBlockTypes } from "@minecraft/server";
 
 export const VEIN_BLOCKS_LIST = [
   // Logs
-  MinecraftBlockTypes.log.id,
-  MinecraftBlockTypes.log2.id,
+  MinecraftBlockTypes.oakLog.id,
+  MinecraftBlockTypes.birchLog.id,
+  MinecraftBlockTypes.acaciaLog.id,
+  MinecraftBlockTypes.cherryLog.id,
+  MinecraftBlockTypes.jungleLog.id,
+  MinecraftBlockTypes.spruceLog.id,
+  MinecraftBlockTypes.darkOakLog.id,
   MinecraftBlockTypes.mangroveLog.id,
 
   // Ore


### PR DESCRIPTION
Update Log Block IDs for the IDs used by individual trees in 1.19.80

Bump MC Version