### PR TITLE
Update minecraft server to 1.4 beta-stable

### DIFF
--- a/behavior_packs/jl-fast-treecapitator/manifest.json
+++ b/behavior_packs/jl-fast-treecapitator/manifest.json
@@ -4,7 +4,7 @@
     "name": "JL Fast Treecapitator",
     "description": "Mine trees and veins in 1 click, fast!",
     "uuid": "b1da7c74-d155-4686-a9aa-33d5a6c48da0",
-    "version": [1, 0, 2],
+    "version": [1, 0, 3],
     "min_engine_version": [1, 19, 40]
   },
   "modules": [
@@ -13,14 +13,14 @@
       "language": "javascript",
       "type": "script",
       "uuid": "5ec7117f-d362-4b5b-918e-23f9b3d76476",
-      "version": [1, 0, 2],
+      "version": [1, 0, 3],
       "entry": "scripts/main.js"
     }
   ],
   "dependencies": [
     {
       "module_name": "@minecraft/server",
-      "version": "1.3.0-beta"
+      "version": "1.4.0-beta"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "scripting-starter",
       "version": "0.1.0",
       "dependencies": {
-        "@minecraft/server": "^1.3.0-beta.1.20.0-stable",
+        "@minecraft/server": "1.4.0-beta.1.20.10-stable",
         "decode-uri-component": "^0.2.2"
       },
       "devDependencies": {
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@minecraft/server": {
-      "version": "1.3.0-beta.1.20.0-stable",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.3.0-beta.1.20.0-stable.tgz",
-      "integrity": "sha512-OBmJv81WzV55r7M7wwgFFTormGr6qrR4cwCWlylMQeVhbmS+x6FKYOrTahKHxcBugz0rfYl6i154TqC0FTUDEQ=="
+      "version": "1.4.0-beta.1.20.10-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.4.0-beta.1.20.10-stable.tgz",
+      "integrity": "sha512-GFxR3rc83fLG4G1QV51D6a7V1EylomZrUMO1oUNINhkMpNBe2ACA9CBpLpkixxg0Y3aDpUnTkuhjQpoMnekPSA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5180,9 +5180,9 @@
       }
     },
     "@minecraft/server": {
-      "version": "1.3.0-beta.1.20.0-stable",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.3.0-beta.1.20.0-stable.tgz",
-      "integrity": "sha512-OBmJv81WzV55r7M7wwgFFTormGr6qrR4cwCWlylMQeVhbmS+x6FKYOrTahKHxcBugz0rfYl6i154TqC0FTUDEQ=="
+      "version": "1.4.0-beta.1.20.10-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.4.0-beta.1.20.10-stable.tgz",
+      "integrity": "sha512-GFxR3rc83fLG4G1QV51D6a7V1EylomZrUMO1oUNINhkMpNBe2ACA9CBpLpkixxg0Y3aDpUnTkuhjQpoMnekPSA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "enablemcpreviewloopback": "CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-424268864-5579737-879501358-346833251-474568803-887069379-4040235476"
   },
   "dependencies": {
-    "@minecraft/server": "^1.3.0-beta.1.20.0-stable",
+    "@minecraft/server": "1.4.0-beta.1.20.10-stable",
     "decode-uri-component": "^0.2.2"
   }
 }


### PR DESCRIPTION
- Update to user @minecraft/server 1.4.0 stable beta. Save exact minecraft version instead of using newest by default
- Bump manifest versions

Resolves
https://github.com/laynebritton/jl-fast-treecapitator/issues/22