### PR TITLE
Remove faulty initialization logic from User Config

### DIFF
--- a/behavior_packs/jl-fast-treecapitator/manifest.json
+++ b/behavior_packs/jl-fast-treecapitator/manifest.json
@@ -2,7 +2,7 @@
   "format_version": 2,
   "header": {
     "name": "JL Fast Treecapitator",
-    "description": "Mine trees and veins in 1 click, fast! v1.1.0",
+    "description": "Mine trees and veins in 1 click, fast! v1.1.1",
     "uuid": "0ec989c0-b044-439b-8bf3-39db645141b2",
     "version": [1, 1, 1],
     "min_engine_version": [1, 20, 10]

--- a/behavior_packs/jl-fast-treecapitator/manifest.json
+++ b/behavior_packs/jl-fast-treecapitator/manifest.json
@@ -4,7 +4,7 @@
     "name": "JL Fast Treecapitator",
     "description": "Mine trees and veins in 1 click, fast! v1.1.0",
     "uuid": "0ec989c0-b044-439b-8bf3-39db645141b2",
-    "version": [1, 1, 0],
+    "version": [1, 1, 1],
     "min_engine_version": [1, 20, 10]
   },
   "modules": [
@@ -13,7 +13,7 @@
       "language": "javascript",
       "type": "script",
       "uuid": "c01fc4df-7f42-4cbf-b398-62d4230b9f92",
-      "version": [1, 1, 0],
+      "version": [1, 1, 1],
       "entry": "scripts/main.js"
     }
   ],

--- a/behavior_packs/jl-fast-treecapitator/manifest.json
+++ b/behavior_packs/jl-fast-treecapitator/manifest.json
@@ -2,9 +2,9 @@
   "format_version": 2,
   "header": {
     "name": "JL Fast Treecapitator",
-    "description": "Mine trees and veins in 1 click, fast! v1.1.1",
+    "description": "Mine trees and veins in 1 click, fast! v1.1.2",
     "uuid": "0ec989c0-b044-439b-8bf3-39db645141b2",
-    "version": [1, 1, 1],
+    "version": [1, 1, 2],
     "min_engine_version": [1, 20, 10]
   },
   "modules": [
@@ -13,7 +13,7 @@
       "language": "javascript",
       "type": "script",
       "uuid": "c01fc4df-7f42-4cbf-b398-62d4230b9f92",
-      "version": [1, 1, 1],
+      "version": [1, 1, 2],
       "entry": "scripts/main.js"
     }
   ],

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -21,25 +21,6 @@ world.afterEvents.playerBreakBlock.subscribe(
   }
 );
 
-world.afterEvents.worldInitialize.subscribe((event) => {
-  // First time set up if no prior config exists
-  const config = world.getDynamicProperty("config");
-  const allowSet = world.getDynamicProperty("allowSet");
-  const removeSet = world.getDynamicProperty("removeSet");
-
-  if (!config) {
-    world.setDynamicProperty("config", JSON.stringify({}));
-  }
-
-  if (!allowSet) {
-    world.setDynamicProperty("allowSet", JSON.stringify({}));
-  }
-
-  if (!removeSet) {
-    world.setDynamicProperty("removeSet", JSON.stringify({}));
-  }
-});
-
 world.afterEvents.chatSend.subscribe(
   (chatSendAfterEvent: ChatSendAfterEvent) => {
     UserCLIEvent(chatSendAfterEvent);


### PR DESCRIPTION
Delete the after worldInitialize event that was setting bad data in the dynamic properties. 

The helper classes in the dynamic properties cover the not instantiated yet case, so this is redundant and harmful. 

See https://github.com/laynebritton/jl-fast-treecapitator/blob/main/scripts/DynamicProperties/AllowSet.ts#L19-L22 and https://github.com/laynebritton/jl-fast-treecapitator/blob/main/scripts/DynamicProperties/JLTreeCapConfig.ts.ts#L16-L19