### PR TITLE
Support Minecraft 1.21

### DIFF
--- a/behavior_packs/jl-fast-treecapitator/manifest.json
+++ b/behavior_packs/jl-fast-treecapitator/manifest.json
@@ -2,9 +2,9 @@
   "format_version": 2,
   "header": {
     "name": "JL Fast Treecapitator",
-    "description": "Mine trees and veins in 1 click, fast! v1.1.5",
+    "description": "Mine trees and veins in 1 click, fast! v1.1.6",
     "uuid": "0ec989c0-b044-439b-8bf3-39db645141b2",
-    "version": [1, 1, 5],
+    "version": [1, 1, 6],
     "min_engine_version": [1, 20, 10]
   },
   "modules": [
@@ -13,14 +13,14 @@
       "language": "javascript",
       "type": "script",
       "uuid": "c01fc4df-7f42-4cbf-b398-62d4230b9f92",
-      "version": [1, 1, 5],
+      "version": [1, 1, 6],
       "entry": "scripts/main.js"
     }
   ],
   "dependencies": [
     {
       "module_name": "@minecraft/server",
-      "version": "1.10.0-beta"
+      "version": "1.11.0"
     }
   ]
 }

--- a/behavior_packs/jl-fast-treecapitator/manifest.json
+++ b/behavior_packs/jl-fast-treecapitator/manifest.json
@@ -20,7 +20,7 @@
   "dependencies": [
     {
       "module_name": "@minecraft/server",
-      "version": "1.11.0"
+      "version": "1.12.0-beta"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "scripting-starter",
       "version": "0.1.0",
       "dependencies": {
-        "@minecraft/server": "1.12.0-beta.1.21.0-stable",
+        "@minecraft/server": "^1.12.0-beta.1.21.0-stable",
         "decode-uri-component": "^0.2.2",
         "gulp": "^4.0.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "scripting-starter",
       "version": "0.1.0",
       "dependencies": {
-        "@minecraft/server": "^1.10.0-beta.1.20.70-stable",
+        "@minecraft/server": "1.12.0-beta.1.21.0-stable",
         "decode-uri-component": "^0.2.2",
         "gulp": "^4.0.2"
       },
@@ -87,9 +87,9 @@
       "integrity": "sha512-stbUtINCXbcLNRlGNVX68xRC6ZYq3k3CYmfptwrCcPBEUjVOpVkSj3H4Y0qiSYB+1rVWv7DgiP7Uf9++50Ne5g=="
     },
     "node_modules/@minecraft/server": {
-      "version": "1.10.0-beta.1.20.70-stable",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.10.0-beta.1.20.70-stable.tgz",
-      "integrity": "sha512-LzF4F42BXeFbwdmD8CAEzMwYWtxMJUI/WFhZxyJB5nMLgjthhiTVPQ4aq0jIVyitD/w4afQ62/1xe0V7Qc6eHw==",
+      "version": "1.12.0-beta.1.21.0-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.12.0-beta.1.21.0-stable.tgz",
+      "integrity": "sha512-Dkn+H+q/tKZOmjoKDSF9gVXtcc2hn92EvwgkFG0JMxwYYI77gjn8UqYR4I3eZdlM0TJsY0MlyF8IIvRDywJkGA==",
       "dependencies": {
         "@minecraft/common": "^1.1.0"
       }
@@ -4832,9 +4832,9 @@
       "integrity": "sha512-stbUtINCXbcLNRlGNVX68xRC6ZYq3k3CYmfptwrCcPBEUjVOpVkSj3H4Y0qiSYB+1rVWv7DgiP7Uf9++50Ne5g=="
     },
     "@minecraft/server": {
-      "version": "1.10.0-beta.1.20.70-stable",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.10.0-beta.1.20.70-stable.tgz",
-      "integrity": "sha512-LzF4F42BXeFbwdmD8CAEzMwYWtxMJUI/WFhZxyJB5nMLgjthhiTVPQ4aq0jIVyitD/w4afQ62/1xe0V7Qc6eHw==",
+      "version": "1.12.0-beta.1.21.0-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.12.0-beta.1.21.0-stable.tgz",
+      "integrity": "sha512-Dkn+H+q/tKZOmjoKDSF9gVXtcc2hn92EvwgkFG0JMxwYYI77gjn8UqYR4I3eZdlM0TJsY0MlyF8IIvRDywJkGA==",
       "requires": {
         "@minecraft/common": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "enablemcpreviewloopback": "CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-424268864-5579737-879501358-346833251-474568803-887069379-4040235476"
   },
   "dependencies": {
-    "@minecraft/server": "^1.10.0-beta.1.20.70-stable",
+    "@minecraft/server": "1.12.0-beta.1.21.0-stable",
     "decode-uri-component": "^0.2.2",
     "gulp": "^4.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "enablemcpreviewloopback": "CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-424268864-5579737-879501358-346833251-474568803-887069379-4040235476"
   },
   "dependencies": {
-    "@minecraft/server": "1.12.0-beta.1.21.0-stable",
+    "@minecraft/server": "^1.12.0-beta.1.21.0-stable",
     "decode-uri-component": "^0.2.2",
     "gulp": "^4.0.2"
   }


### PR DESCRIPTION
Update for Minecraft version 1.21

Just a version bump to latest stable beta. Tested on bedrock version `v1.21.0`


https://github.com/laynebritton/jl-fast-treecapitator/assets/21363865/d9387e5f-9cc0-44c4-9b49-c670e11a48ac

