### PR TITLE
Update for v1.21.62. use 1.18 beta api

### DIFF
--- a/behavior_packs/jl-fast-treecapitator/manifest.json
+++ b/behavior_packs/jl-fast-treecapitator/manifest.json
@@ -2,9 +2,9 @@
   "format_version": 2,
   "header": {
     "name": "JL Fast Treecapitator",
-    "description": "Mine trees and veins in 1 click, fast! v2.0.5",
+    "description": "Mine trees and veins in 1 click, fast! v2.0.6",
     "uuid": "0ec989c0-b044-439b-8bf3-39db645141b2",
-    "version": [2, 0, 5],
+    "version": [2, 0, 6],
     "min_engine_version": [1, 20, 10]
   },
   "modules": [
@@ -13,14 +13,14 @@
       "language": "javascript",
       "type": "script",
       "uuid": "c01fc4df-7f42-4cbf-b398-62d4230b9f92",
-      "version": [2, 0, 5],
+      "version": [2, 0, 6],
       "entry": "scripts/main.js"
     }
   ],
   "dependencies": [
     {
       "module_name": "@minecraft/server",
-      "version": "1.17.0-beta"
+      "version": "1.18.0-beta"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "scripting-starter",
       "version": "0.1.0",
       "dependencies": {
-        "@minecraft/server": "^1.17.0-beta.1.21.50-stable",
+        "@minecraft/server": "^1.18.0-beta.1.21.62-stable",
         "decode-uri-component": "^0.2.2",
         "gulp": "^4.0.2"
       },
@@ -87,9 +87,10 @@
       "integrity": "sha512-stbUtINCXbcLNRlGNVX68xRC6ZYq3k3CYmfptwrCcPBEUjVOpVkSj3H4Y0qiSYB+1rVWv7DgiP7Uf9++50Ne5g=="
     },
     "node_modules/@minecraft/server": {
-      "version": "1.17.0-beta.1.21.50-stable",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.17.0-beta.1.21.50-stable.tgz",
-      "integrity": "sha512-1z4JDpAuHqkYAqSV2URQdpl9rHMxkSuY2b7TspIODNCmX/aiDUiQrB1rjAiKv6/OTMnIU3TZ+7NezBZbPt4azQ==",
+      "version": "1.18.0-beta.1.21.62-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.18.0-beta.1.21.62-stable.tgz",
+      "integrity": "sha512-3x+4BcX+0sJPW0BS/V/gYb+3WBJdl6LCg1TvOlcLDtExtKb+DsOHtUojvvtsoP2Vhzx1dJr9rzChH3E2JZIadQ==",
+      "license": "MIT",
       "dependencies": {
         "@minecraft/common": "^1.1.0"
       },
@@ -4841,9 +4842,9 @@
       "integrity": "sha512-stbUtINCXbcLNRlGNVX68xRC6ZYq3k3CYmfptwrCcPBEUjVOpVkSj3H4Y0qiSYB+1rVWv7DgiP7Uf9++50Ne5g=="
     },
     "@minecraft/server": {
-      "version": "1.17.0-beta.1.21.50-stable",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.17.0-beta.1.21.50-stable.tgz",
-      "integrity": "sha512-1z4JDpAuHqkYAqSV2URQdpl9rHMxkSuY2b7TspIODNCmX/aiDUiQrB1rjAiKv6/OTMnIU3TZ+7NezBZbPt4azQ==",
+      "version": "1.18.0-beta.1.21.62-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.18.0-beta.1.21.62-stable.tgz",
+      "integrity": "sha512-3x+4BcX+0sJPW0BS/V/gYb+3WBJdl6LCg1TvOlcLDtExtKb+DsOHtUojvvtsoP2Vhzx1dJr9rzChH3E2JZIadQ==",
       "requires": {
         "@minecraft/common": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "enablemcpreviewloopback": "CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-424268864-5579737-879501358-346833251-474568803-887069379-4040235476"
   },
   "dependencies": {
-    "@minecraft/server": "^1.17.0-beta.1.21.50-stable",
+    "@minecraft/server": "^1.18.0-beta.1.21.62-stable",
     "decode-uri-component": "^0.2.2",
     "gulp": "^4.0.2"
   }


### PR DESCRIPTION
Version bump. 

Beta APIs have moved to `1.18` version. See npm registry for `@minecraft/server` https://www.npmjs.com/package/@minecraft/server?activeTab=versions

Chat utilities are **still** only in beta 😔 


Tested on local world