### PR TITLE
Update for 1.21.81. Update world API calls for breaking 2.0.0 changes

### DIFF
--- a/behavior_packs/jl-fast-treecapitator/manifest.json
+++ b/behavior_packs/jl-fast-treecapitator/manifest.json
@@ -2,9 +2,9 @@
   "format_version": 2,
   "header": {
     "name": "JL Fast Treecapitator",
-    "description": "Mine trees and veins in 1 click, fast! v2.0.6",
+    "description": "Mine trees and veins in 1 click, fast! v2.0.7",
     "uuid": "0ec989c0-b044-439b-8bf3-39db645141b2",
-    "version": [2, 0, 6],
+    "version": [2, 0, 7],
     "min_engine_version": [1, 20, 10]
   },
   "modules": [
@@ -13,14 +13,14 @@
       "language": "javascript",
       "type": "script",
       "uuid": "c01fc4df-7f42-4cbf-b398-62d4230b9f92",
-      "version": [2, 0, 6],
+      "version": [2, 0, 7],
       "entry": "scripts/main.js"
     }
   ],
   "dependencies": [
     {
       "module_name": "@minecraft/server",
-      "version": "1.18.0-beta"
+      "version": "2.0.0-beta"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "scripting-starter",
       "version": "0.1.0",
       "dependencies": {
-        "@minecraft/server": "^1.18.0-beta.1.21.62-stable",
+        "@minecraft/server": "^2.0.0-beta.1.21.81-stable",
         "decode-uri-component": "^0.2.2",
         "gulp": "^4.0.2"
       },
@@ -18,7 +18,7 @@
         "gulp-sourcemaps": "^3.0.0",
         "gulp-typescript": "^6.0.0-alpha.1",
         "source-map": "^0.7.4",
-        "typescript": "^4.4.3"
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@gulp-sourcemaps/identity-map": {
@@ -87,9 +87,9 @@
       "integrity": "sha512-stbUtINCXbcLNRlGNVX68xRC6ZYq3k3CYmfptwrCcPBEUjVOpVkSj3H4Y0qiSYB+1rVWv7DgiP7Uf9++50Ne5g=="
     },
     "node_modules/@minecraft/server": {
-      "version": "1.18.0-beta.1.21.62-stable",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.18.0-beta.1.21.62-stable.tgz",
-      "integrity": "sha512-3x+4BcX+0sJPW0BS/V/gYb+3WBJdl6LCg1TvOlcLDtExtKb+DsOHtUojvvtsoP2Vhzx1dJr9rzChH3E2JZIadQ==",
+      "version": "2.0.0-beta.1.21.81-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-2.0.0-beta.1.21.81-stable.tgz",
+      "integrity": "sha512-MxP5YlonQ3YhSaTiwZ62vYwmdBcK2iLE1PhQgcIrsgJ8MZfpjWRsJrNb1Z0dHoozgY5d9Bk8eNiPu6k3wCzNgQ==",
       "license": "MIT",
       "dependencies": {
         "@minecraft/common": "^1.1.0"
@@ -4465,16 +4465,17 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unc-path-regex": {
@@ -4842,9 +4843,9 @@
       "integrity": "sha512-stbUtINCXbcLNRlGNVX68xRC6ZYq3k3CYmfptwrCcPBEUjVOpVkSj3H4Y0qiSYB+1rVWv7DgiP7Uf9++50Ne5g=="
     },
     "@minecraft/server": {
-      "version": "1.18.0-beta.1.21.62-stable",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.18.0-beta.1.21.62-stable.tgz",
-      "integrity": "sha512-3x+4BcX+0sJPW0BS/V/gYb+3WBJdl6LCg1TvOlcLDtExtKb+DsOHtUojvvtsoP2Vhzx1dJr9rzChH3E2JZIadQ==",
+      "version": "2.0.0-beta.1.21.81-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-2.0.0-beta.1.21.81-stable.tgz",
+      "integrity": "sha512-MxP5YlonQ3YhSaTiwZ62vYwmdBcK2iLE1PhQgcIrsgJ8MZfpjWRsJrNb1Z0dHoozgY5d9Bk8eNiPu6k3wCzNgQ==",
       "requires": {
         "@minecraft/common": "^1.1.0"
       }
@@ -8249,9 +8250,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true
     },
     "unc-path-regex": {

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "gulp-sourcemaps": "^3.0.0",
     "gulp-typescript": "^6.0.0-alpha.1",
     "source-map": "^0.7.4",
-    "typescript": "^4.4.3"
+    "typescript": "^5.8.3"
   },
   "scripts": {
     "enablemcloopback": "CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-1958404141-86561845-1752920682-3514627264-368642714-62675701-733520436",
     "enablemcpreviewloopback": "CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-424268864-5579737-879501358-346833251-474568803-887069379-4040235476"
   },
   "dependencies": {
-    "@minecraft/server": "^1.18.0-beta.1.21.62-stable",
+    "@minecraft/server": "^2.0.0-beta.1.21.81-stable",
     "decode-uri-component": "^0.2.2",
     "gulp": "^4.0.2"
   }

--- a/scripts/Debug.ts
+++ b/scripts/Debug.ts
@@ -1,5 +1,5 @@
 import { world } from "@minecraft/server";
 
 export const say = (message: String) => {
-  world.getDimension("overworld").runCommandAsync(`say ${message}`);
+  world.getDimension("overworld").runCommand(`say ${message}`);
 };

--- a/scripts/Utilities.ts
+++ b/scripts/Utilities.ts
@@ -26,5 +26,5 @@ export const destroy = (
 export const systemOutput = (message: String) => {
   world
     .getDimension("overworld")
-    .runCommandAsync(`say §2${SYSTEM_CHAT_PREFIX} §f${message}`);
+    .runCommand(`say §2${SYSTEM_CHAT_PREFIX} §f${message}`);
 };


### PR DESCRIPTION
- Update Beta API to `2.0.0`
- Update typescript to latest, required for latest 2.0.0 beta API

Breaking changes
- Migrate `runCommandAsync` to `runCommand` due to the removal of `runCommandAsync`. This may impact performance on servers with huge player concurrent player counts. This unblocks use on the latest versions, but performance depending we may need to open a ticket with Microsoft to bring this back https://learn.microsoft.com/en-us/minecraft/creator/scriptapi/minecraft/server/dimension?view=minecraft-bedrock-experimental#runcommand

Tested all features on local world.

Chat before and after events are in beta until stable reaches version 1.21 https://www.npmjs.com/package/@minecraft/server?activeTab=versions 😔

Resolves: https://github.com/laynebritton/jl-fast-treecapitator/issues/64


